### PR TITLE
Move side effects out of MutablePermissionState #45

### DIFF
--- a/permissions/src/main/java/com/patochallen/permissions/camera/RequestCameraPermission.kt
+++ b/permissions/src/main/java/com/patochallen/permissions/camera/RequestCameraPermission.kt
@@ -8,8 +8,8 @@ import com.patochallen.permissions.common.PermissionStrings
 import com.patochallen.permissions.common.RequestPermission
 import com.patochallen.permissions.model.ExperimentalApi
 
-@Composable
 @ExperimentalApi
+@Composable
 fun RequestCameraPermission(
     strings: PermissionStrings = PermissionDefaults.cameraStrings(),
     content: @Composable (() -> Unit)

--- a/permissions/src/main/java/com/patochallen/permissions/common/RequestPermission.kt
+++ b/permissions/src/main/java/com/patochallen/permissions/common/RequestPermission.kt
@@ -11,8 +11,8 @@ import com.patochallen.permissions.model.PermissionStatus.ShowRational
 import com.patochallen.permissions.model.rememberPermissionState
 import com.patochallen.permissions.utils.launchSettingsIntent
 
-@Composable
 @ExperimentalApi
+@Composable
 fun RequestPermission(
     permission: String,
     strings: PermissionStrings,
@@ -41,8 +41,8 @@ fun RequestPermission(
     content = content
 )
 
-@Composable
 @ExperimentalApi
+@Composable
 internal fun RequestPermission(
     permission: String,
     showRationalContent: @Composable ((onClick: () -> Unit) -> Unit),

--- a/permissions/src/main/java/com/patochallen/permissions/location/RequestLocationPermission.kt
+++ b/permissions/src/main/java/com/patochallen/permissions/location/RequestLocationPermission.kt
@@ -8,8 +8,8 @@ import com.patochallen.permissions.common.PermissionStrings
 import com.patochallen.permissions.common.RequestPermission
 import com.patochallen.permissions.model.ExperimentalApi
 
-@Composable
 @ExperimentalApi
+@Composable
 fun RequestLocationPermission(
     strings: PermissionStrings = PermissionDefaults.locationStrings(),
     content: @Composable (() -> Unit)

--- a/permissions/src/main/java/com/patochallen/permissions/microphone/RequestMicrophonePermission.kt
+++ b/permissions/src/main/java/com/patochallen/permissions/microphone/RequestMicrophonePermission.kt
@@ -8,8 +8,8 @@ import com.patochallen.permissions.common.PermissionStrings
 import com.patochallen.permissions.common.RequestPermission
 import com.patochallen.permissions.model.ExperimentalApi
 
-@Composable
 @ExperimentalApi
+@Composable
 fun RequestMicrophonePermission(
     strings: PermissionStrings = PermissionDefaults.microphoneStrings(),
     content: @Composable (() -> Unit)

--- a/permissions/src/main/java/com/patochallen/permissions/model/CheckLifecycleResumeEventEffect.kt
+++ b/permissions/src/main/java/com/patochallen/permissions/model/CheckLifecycleResumeEventEffect.kt
@@ -1,0 +1,30 @@
+package com.patochallen.permissions.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.LifecycleEventObserver
+
+/**
+ * Effect that observes the lifecycle and notify when is called with [ON_RESUME] event.
+ *
+ * @param onResume the callback to be called when the lifecycle event is [ON_RESUME].
+ */
+@Composable
+fun CheckLifecycleResumeEventEffect(
+    onResume: () -> Unit
+) {
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+
+    DisposableEffect(lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == ON_RESUME) {
+                onResume()
+            }
+        }
+        lifecycle.addObserver(observer)
+
+        onDispose { lifecycle.removeObserver(observer) }
+    }
+}

--- a/permissions/src/main/java/com/patochallen/permissions/model/MutablePermissionState.kt
+++ b/permissions/src/main/java/com/patochallen/permissions/model/MutablePermissionState.kt
@@ -2,21 +2,14 @@ package com.patochallen.permissions.model
 
 import android.app.Activity
 import android.content.Context
-import androidx.activity.compose.ManagedActivityResultLauncher
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Lifecycle.Event.ON_RESUME
-import androidx.lifecycle.LifecycleEventObserver
 import com.patochallen.permissions.utils.checkPermission
 import com.patochallen.permissions.utils.findActivity
 import com.patochallen.permissions.utils.shouldShowRationale
@@ -33,39 +26,22 @@ internal fun rememberMutablePermissionState(
     permission: String,
 ): MutablePermissionState {
     val context = LocalContext.current
-    val lifecycle = LocalLifecycleOwner.current.lifecycle
 
-    val permissionState: MutablePermissionState = remember(permission) {
+    val launcher = rememberLauncherPermissionForResult()
+
+    val permissionState = remember(permission) {
         MutablePermissionState(
             permission = permission,
             context = context,
-            activity = context.findActivity()
+            activity = context.findActivity(),
+            launcher = launcher
         )
     }
 
-    val lifecycleObserver: LifecycleEventObserver = remember(permissionState) {
-        LifecycleEventObserver { _, event ->
-            if (event == ON_RESUME && permissionState.status != PermissionStatus.Granted) {
-                permissionState.refreshPermissionStatus()
-            }
-        }
-    }
-
-    val launcher: ManagedActivityResultLauncher<String, Boolean> =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+    CheckLifecycleResumeEventEffect {
+        if (permissionState.status != PermissionStatus.Granted) {
             permissionState.refreshPermissionStatus()
         }
-
-    DisposableEffect(lifecycle, permissionState) {
-        lifecycle.addObserver(lifecycleObserver)
-
-        onDispose { lifecycle.removeObserver(lifecycleObserver) }
-    }
-
-    DisposableEffect(permissionState, launcher) {
-        permissionState.launcher = launcher
-
-        onDispose { permissionState.launcher = null }
     }
 
     return permissionState
@@ -76,64 +52,55 @@ internal fun rememberMutablePermissionState(
  *
  * @param permission the permission to check.
  * @param context is required to check if the requested [permission] is granted.
- * @param activity is required to check if it is necessary to show a rationale
- * for the requested [permission] to the user.
+ * @param activity is required to check if it is necessary to show a rationale for the requested [permission] to the user.
+ * @param launcher the [ActivityResultLauncher] that can be used to start the activity.
  */
 @ExperimentalApi
 @Stable
 internal class MutablePermissionState(
     override val permission: String,
     private val context: Context,
-    private val activity: Activity
+    private val activity: Activity,
+    private val launcher: ActivityResultLauncher<String>
 ) : PermissionState {
 
     override var status: PermissionStatus by mutableStateOf(getPermissionStatus())
 
     override fun requestPermission() {
-        launcher?.launch(
-            permission
-        )
+        launcher.launch(permission)
     }
-
-    internal var launcher: ActivityResultLauncher<String>? = null
 
     internal fun refreshPermissionStatus() {
         status = getPermissionStatus()
     }
 
-    private fun hasPermission(): Boolean =
-        context.checkPermission(permission)
-            .also { hasPermission ->
-                if (hasPermission) {
-                    setRationalViewed(false)
-                }
+    private fun hasPermission(): Boolean = context.checkPermission(permission)
+        .also { hasPermission ->
+            if (hasPermission) {
+                setRationalViewed(false)
             }
+        }
 
-    private fun shouldShowRational(): Boolean =
-        activity.shouldShowRationale(permission)
-            .also { shouldShowRational ->
-                if (shouldShowRational) {
-                    setRationalViewed(true)
-                }
+    private fun shouldShowRational(): Boolean = activity.shouldShowRationale(permission)
+        .also { shouldShowRational ->
+            if (shouldShowRational) {
+                setRationalViewed(true)
             }
+        }
 
     private fun hasRationalViewed(): Boolean = activity
         .getPreferences(Context.MODE_PRIVATE)
         .getBoolean(permission, false)
 
-    private fun setRationalViewed(hasViewed: Boolean) {
-        activity
-            .getPreferences(Context.MODE_PRIVATE)
-            .edit()
-            .putBoolean(permission, hasViewed)
-            .apply()
-    }
+    private fun setRationalViewed(hasViewed: Boolean) = activity
+        .getPreferences(Context.MODE_PRIVATE)
+        .edit()
+        .putBoolean(permission, hasViewed)
+        .apply()
 
-    private fun getPermissionStatus(): PermissionStatus {
-        return when {
-            hasPermission() -> PermissionStatus.Granted
-            shouldShowRational() || hasRationalViewed().not() -> PermissionStatus.ShowRational
-            else -> PermissionStatus.Denied
-        }
+    private fun getPermissionStatus(): PermissionStatus = when {
+        hasPermission() -> PermissionStatus.Granted
+        shouldShowRational() || hasRationalViewed().not() -> PermissionStatus.ShowRational
+        else -> PermissionStatus.Denied
     }
 }

--- a/permissions/src/main/java/com/patochallen/permissions/model/RememberLauncherPermissionForResult.kt
+++ b/permissions/src/main/java/com/patochallen/permissions/model/RememberLauncherPermissionForResult.kt
@@ -1,0 +1,20 @@
+package com.patochallen.permissions.model
+
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.compose.runtime.Composable
+
+/**
+ * Register a request to start an activity for result, designated to [request a permission][Activity.requestPermissions].
+ *
+ * @param onResult the callback to be called on the main thread when activity result is available.
+ * @return the [launcher][rememberLauncherForActivityResult] that can be used to start the activity.
+ */
+@Composable
+internal fun rememberLauncherPermissionForResult(
+    onResult: (Boolean) -> Unit = {}
+) = rememberLauncherForActivityResult(
+    contract = RequestPermission(),
+    onResult = onResult
+)


### PR DESCRIPTION
## Summary

* CheckActivityResultEffect and RememberLauncherPermissionForResult created
* launcher moved to constructor of MutablePermissionState
* ExperimentalApi annotation moved to top of annotations